### PR TITLE
Fix typos in instructions list

### DIFF
--- a/book/src/cpu/register_data_instructions.md
+++ b/book/src/cpu/register_data_instructions.md
@@ -150,7 +150,7 @@ What are the other types of instructions that act on register data?
 * **RRA** (rotate right A register) - bit rotate A register right through the carry flag
 * **RLA** (rotate left A register) - bit rotate A register left through the carry flag
 * **RRCA** (rotate right A register) - bit rotate A register right (not through the carry flag)
-* **RRLA** (rotate left A register) - bit rotate A register left (not through the carry flag)
+* **RLCA** (rotate left A register) - bit rotate A register left (not through the carry flag)
 * **CPL** (complement) - toggle every bit of the A register
 * **BIT** (bit test) - test to see if a specific bit of a specific register is set
 * **RESET** (bit reset) - set a specific bit of a specific register to 0
@@ -158,8 +158,8 @@ What are the other types of instructions that act on register data?
 * **SRL** (shift right logical) - bit shift a specific register right by 1
 * **RR** (rotate right) - bit rotate a specific register right by 1 through the carry flag
 * **RL** (rotate left) - bit rotate a specific register left by 1 through the carry flag
-* **RRC** (rorate right) - bit rotate a specific register right by 1 (not through the carry flag)
-* **RLC** (rorate left) - bit rotate a specific register left by 1 (not through the carry flag)
+* **RRC** (rotate right) - bit rotate a specific register right by 1 (not through the carry flag)
+* **RLC** (rotate left) - bit rotate a specific register left by 1 (not through the carry flag)
 * **SRA** (shift right arithmetic) - arithmetic shift a specific register right by 1
 * **SLA** (shift left arithmetic) - arithmetic shift a specific register left by 1
 * **SWAP** (swap nibbles) - switch upper and lower nibble of a specific register


### PR DESCRIPTION
Corrections of the instruction name is taken from http://marc.rawer.de/Gameboy/Docs/GBCPUman.pdf