### PR TITLE
Change color palette in tile_ram.md

### DIFF
--- a/book/src/graphics/tile_ram.md
+++ b/book/src/graphics/tile_ram.md
@@ -34,10 +34,10 @@ The bit value to color mapping is as follows:
 
 ```ignore
 +------+------------+
-| 0b11 | white      |
-| 0b10 | dark-gray  |
-| 0b01 | light-gray |
-| 0b00 | black      |
+| 0b00 | white      |
+| 0b01 | dark-gray  |
+| 0b10 | light-gray |
+| 0b11 | black      |
 +------+------------+
 ```
 


### PR DESCRIPTION
I assume the color palette here was in the wrong order. When developing my own emulator following this guide, I found that the colors appear inverted.

Looking at this other guide, they seem to say 00 = white, and 11 = black.
https://gbdev.io/pandocs/Palettes.html