### PR TITLE
Fix broken links to appendix pages from pages in CPU section

### DIFF
--- a/public/book/cpu/register_data_instructions.html
+++ b/public/book/cpu/register_data_instructions.html
@@ -254,7 +254,7 @@ impl CPU {
 <p>Yout might be wondering, &quot;how do we know what to do given a certain the instruction&quot;. The short answer is that this is just how the chip was specified  and manufactured to worked. We know this because people have either read the original user's manual for the Game Boy's CPU chip (known as a &quot;data sheet&quot;),or they've written test programs for the chip that call specific instructions and see what happens. Luckily you don't need to do this. You can find descriptions of all the instructions <a href="../appendix/instruction_guide/index.html">in the instruction guide</a>.</p>
 <blockquote>
 <p><em>Side Note</em></p>
-<p>Most CPU instructions that deal with register data manipulate that data through various bitwise operations. If the likes of logical shifts and bitwise ands aren't super clear to you, check out the <a href="./appendix/bit_manipulation.html">guide on bit manipulation</a>.</p>
+<p>Most CPU instructions that deal with register data manipulate that data through various bitwise operations. If the likes of logical shifts and bitwise ands aren't super clear to you, check out the <a href="../appendix/bit_manipulation.html">guide on bit manipulation</a>.</p>
 </blockquote>
 <p>What are the other types of instructions that act on register data?</p>
 <ul>

--- a/public/book/cpu/registers.html
+++ b/public/book/cpu/registers.html
@@ -154,7 +154,7 @@
   l: u8,
 }
 </code></pre>
-<p>We use the type <code>u8</code> for our registers. <code>u8</code> are 8-bit unsigned integers. For a refresher on how numbers are stored in computers, checkout the <a href="./appendix/numbers.html">guide on numbers</a>.</p>
+<p>We use the type <code>u8</code> for our registers. <code>u8</code> are 8-bit unsigned integers. For a refresher on how numbers are stored in computers, checkout the <a href="../appendix/numbers.html">guide on numbers</a>.</p>
 <p>While the CPU only has 8 bit registers, there are instructions that allow the game to read and write 16 bits (i.e. 2 bytes) at the same time (denoted as <code>u16</code> in Rust - a 16 bit unsigned integer). Therefore, we'll need the ability to read an write these &quot;virtual&quot; 16 bit registers. These registers are refered to as &quot;af&quot; (&quot;a&quot; and &quot;f&quot; combined), &quot;bc&quot; (&quot;b&quot; and &quot;c&quot; combined), &quot;de&quot; (&quot;d&quot; and &quot;e&quot; combinded), and finally &quot;hl&quot; (&quot;h&quot; and &quot;l&quot; combined). Let's implement &quot;bc&quot;:</p>
 <pre><code class="language-rust noplaypen"># struct Registers { a: u8, b: u8, c: u8, d: u8, e: u8, f: u8, h: u8, l: u8, }
 impl Registers {
@@ -169,7 +169,7 @@ impl Registers {
   }
 }
 </code></pre>
-<p>Here we see our first instance of &quot;bit manipulation&quot; through the use of four bitwise operators: &quot;&gt;&gt;&quot;, &quot;&lt;&lt;&quot;, &quot;&amp;&quot;, and &quot;|&quot;. If you're unfamiliar with or feel a bit rusty using these types of operators, check out the <a href="./appendix/bit_manipulation.html">guide on bit manipulation</a>.</p>
+<p>Here we see our first instance of &quot;bit manipulation&quot; through the use of four bitwise operators: &quot;&gt;&gt;&quot;, &quot;&lt;&lt;&quot;, &quot;&amp;&quot;, and &quot;|&quot;. If you're unfamiliar with or feel a bit rusty using these types of operators, check out the <a href="../appendix/bit_manipulation.html">guide on bit manipulation</a>.</p>
 <p>For reading the &quot;bc&quot; register we first treat the &quot;b&quot; register as a <code>u16</code> (this effectively just adds a byte of all 0s to the most significant position of the number). We then shift the &quot;b&quot; register 8 positions so that it's occupying the most significant byte position. Finally, we bitwise OR the &quot;c&quot; register. The result is a two byte number with the contents of &quot;b&quot; in the most significant byte position and the contents of &quot;c&quot; in the least significant byte position.</p>
 <a class="header" href="#flags-register" id="flags-register"><h2>Flags Register</h2></a>
 <p>We're almost done with our registers, but there's one thing we way we can improve our registers for use later. The &quot;f&quot; register is a special register called the &quot;flags&quot; register. The lower four bits of the register are <em>always</em> 0s and the CPU automatically writes to the upper four bits when certain things happen. In other words, the CPU &quot;flags&quot; certain states. We won't go into the specific meanings of the flags just yet, but for now just know that they have the following names and positions:</p>


### PR DESCRIPTION
While reading through the published version of the book, I ran into a broken link from the CPU Registers page to the Appendix Numbers page. I've gone through and fixed this and all of the other broken Appendix links in the CPU section of the book.

Example: https://rylev.github.io/DMG-01/public/book/cpu/appendix/numbers.html